### PR TITLE
add a nullcheck to isConnected()

### DIFF
--- a/common/src/main/java/com/abrenoch/hyperiongrabber/common/network/Hyperion.java
+++ b/common/src/main/java/com/abrenoch/hyperiongrabber/common/network/Hyperion.java
@@ -31,7 +31,8 @@ public class Hyperion {
 
 
     public boolean isConnected() {
-        return mSocket.isConnected();
+        //noinspection ConstantConditions for some reason mSocket CAN be null sometimes
+        return mSocket != null && mSocket.isConnected();
     }
 
     public void disconnect() throws IOException {


### PR DESCRIPTION
Not sure why, but I have seen mSocket being null in practice, while it should never be