### PR TITLE
changed framerate preference to string array & updated reference

### DIFF
--- a/common/src/main/java/com/abrenoch/hyperiongrabber/common/HyperionScreenService.java
+++ b/common/src/main/java/com/abrenoch/hyperiongrabber/common/HyperionScreenService.java
@@ -94,7 +94,7 @@ public class HyperionScreenService extends Service {
         String host = prefs.getString(R.string.pref_key_hyperion_host, null);
         int port = prefs.getInt(R.string.pref_key_hyperion_port, -1);
         String priority = prefs.getString(R.string.pref_key_hyperion_priority, "50");
-        mFrameRate = prefs.getInt(R.string.pref_key_hyperion_framerate, 30);
+        mFrameRate = Integer.parseInt(prefs.getString(R.string.pref_key_hyperion_framerate, "30"));
         OGL_GRABBER = prefs.getBoolean(R.string.pref_key_ogl_grabber, false);
         RECONNECT = prefs.getBoolean(R.string.pref_key_reconnect, false);
         int delay = prefs.getInt(R.string.pref_key_reconnect_delay, 5);

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -64,13 +64,13 @@
         <item>30 fps</item>
         <item>60 fps</item>
     </string-array>
-    <integer-array name="pref_list_framerate_values">
+    <string-array name="pref_list_framerate_values">
         <item>10</item>
         <item>15</item>
         <item>24</item>
         <item>30</item>
         <item>60</item>
-    </integer-array>
+    </string-array>
 
     <string name="error_empty_host">Host setting should not be empty</string>
     <string name="error_empty_port">Port setting should not be empty</string>

--- a/tv/src/main/java/com/abrenoch/hyperiongrabber/tv/fragments/settings/BasicSettingsStepFragment.kt
+++ b/tv/src/main/java/com/abrenoch/hyperiongrabber/tv/fragments/settings/BasicSettingsStepFragment.kt
@@ -94,9 +94,9 @@ internal class BasicSettingsStepFragment : SettingsStepBaseFragment() {
                 .build()
 
         val frameRateLabels = resources.getStringArray(R.array.pref_list_framerate)
-        val frameRateValues = resources.getIntArray(R.array.pref_list_framerate_values).toTypedArray()
+        val frameRateValues = resources.getStringArray(R.array.pref_list_framerate_values)
 
-        val selectedCaptureRate = prefs.getInt(R.string.pref_key_hyperion_framerate, 30)
+        val selectedCaptureRate = prefs.getString(R.string.pref_key_hyperion_framerate, "30")
 
         val captureRateDescription =
                 if (prefs.contains(R.string.pref_key_hyperion_framerate)){
@@ -179,7 +179,7 @@ internal class BasicSettingsStepFragment : SettingsStepBaseFragment() {
                 val host = assertValue(ACTION_HOST_NAME)
                 val port = assertIntValue(ACTION_PORT)
                 val startOnBootEnabled = findActionById(ACTION_START_ON_BOOT).isChecked
-                val frameRate = assertSubActionValue(ACTION_CAPTURE_RATE, Int::class.java)
+                val frameRate = assertSubActionValue(ACTION_CAPTURE_RATE, String::class.java)
                 val useOgl = assertSubActionValue(ACTION_GRABBER_GROUP, Boolean::class.java)
                 val reconnect = findSubActionById(ACTION_RECONNECT)!!.isChecked
                 val reconnectDelay = assertIntValue(ACTION_RECONNECT_DELAY)
@@ -188,7 +188,7 @@ internal class BasicSettingsStepFragment : SettingsStepBaseFragment() {
                 prefs.putInt(R.string.pref_key_hyperion_port, port)
                 prefs.putBoolean(R.string.pref_key_start_on_boot, startOnBootEnabled)
                 prefs.putInt(R.string.pref_key_reconnect_delay, reconnectDelay)
-                prefs.putInt(R.string.pref_key_hyperion_framerate, frameRate)
+                prefs.putString(R.string.pref_key_hyperion_framerate, frameRate)
                 prefs.putBoolean(R.string.pref_key_reconnect, reconnect)
                 prefs.putBoolean(R.string.pref_key_ogl_grabber, useOgl)
 


### PR DESCRIPTION
It appears that the `ListPreference` preference option is only intended to hold `string-array` values. Seems ridiculous but it is what it is, without it the mobile settings page crashes the app.

Changes are pretty straightforward - tested on mobile and tv!