### PR TITLE
Feature/manual setup test connection

### DIFF
--- a/tv/src/main/java/com/abrenoch/hyperiongrabber/tv/activities/MainActivity.java
+++ b/tv/src/main/java/com/abrenoch/hyperiongrabber/tv/activities/MainActivity.java
@@ -177,6 +177,7 @@ public class MainActivity extends LeanbackActivity implements ImageView.OnClickL
     }
 
     private void startSettings() {
+        stopScreenRecorder();
         Intent intent = new Intent(this, ManualSetupActivity.class);
         Bundle bundle =
                 ActivityOptionsCompat.makeSceneTransitionAnimation(this)

--- a/tv/src/main/java/com/abrenoch/hyperiongrabber/tv/activities/ScanResultActivity.java
+++ b/tv/src/main/java/com/abrenoch/hyperiongrabber/tv/activities/ScanResultActivity.java
@@ -84,7 +84,7 @@ public class ScanResultActivity extends LeanbackActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        setHyperionColor(hostName, port, -1);
+        setHyperionColor(hostName, port, Color.BLACK);
 
     }
 
@@ -164,13 +164,13 @@ public class ScanResultActivity extends LeanbackActivity {
                 .burst(100);
     }
 
-    /** A color int , or -1 to clear */
+    /** A color int , or Color.BLACK to clear */
     private void setHyperionColor(String hostName, int port, int color){
         new Thread(() -> {
             try {
                 Hyperion hyperion = new Hyperion(hostName, port);
                 if (hyperion.isConnected()){
-                    if (color == -1){
+                    if (color == Color.BLACK){
                         hyperion.clear(50);
                     } else {
                         hyperion.setColor(color, 50);

--- a/tv/src/main/java/com/abrenoch/hyperiongrabber/tv/fragments/settings/BasicSettingsStepFragment.kt
+++ b/tv/src/main/java/com/abrenoch/hyperiongrabber/tv/fragments/settings/BasicSettingsStepFragment.kt
@@ -196,6 +196,7 @@ internal class BasicSettingsStepFragment : SettingsStepBaseFragment() {
                 val host = assertStringValue(ACTION_HOST_NAME)
                 val port = assertIntValue(ACTION_PORT)
                 val startOnBootEnabled = findActionById(ACTION_START_ON_BOOT).isChecked
+                val priority = assertIntValue(ACTION_MESSAGE_PRIORITY)
                 val frameRate = assertSubActionValue(ACTION_CAPTURE_RATE, String::class.java)
                 val useOgl = assertSubActionValue(ACTION_GRABBER_GROUP, Boolean::class.java)
                 val reconnect = findSubActionById(ACTION_RECONNECT)!!.isChecked
@@ -204,6 +205,7 @@ internal class BasicSettingsStepFragment : SettingsStepBaseFragment() {
                 prefs.putString(R.string.pref_key_host, host)
                 prefs.putInt(R.string.pref_key_port, port)
                 prefs.putBoolean(R.string.pref_key_boot, startOnBootEnabled)
+                prefs.putInt(R.string.pref_key_priority, priority)
                 prefs.putInt(R.string.pref_key_reconnect_delay, reconnectDelay)
                 prefs.putString(R.string.pref_key_framerate, frameRate)
                 prefs.putBoolean(R.string.pref_key_reconnect, reconnect)

--- a/tv/src/main/res/values/strings.xml
+++ b/tv/src/main/res/values/strings.xml
@@ -11,8 +11,10 @@
     <string name="guidedstep_section_advanced_description">The settings below can safely be left at their defaults</string>
     <string name="guidedstep_save">Save</string>
     <string name="guidedstep_test">Test</string>
-    <string name="guidedstep_taste_the_rainbow">Taste the rainbow</string>
-    <string name="guidedstep_test_success"></string>
+    <string name="guidedstep_test_description">Shine on</string>
+    <string name="guidedstep_test_success">Result: OK. LEDs not lighting up? Try a lower priority value</string>
+    <string name="guidedstep_test_host_unreachable">Result: Could not connect. Please check host and port</string>
+    <string name="guidedstep_test_unknown_error">Result: unknown error</string>
     <string name="guidedstep_continue">Continue</string>
     <string name="guidedstep_letsdoit">Let\'s do it</string>
     <string name="guidedstep_nevermind">Never mind</string>

--- a/tv/src/main/res/values/strings.xml
+++ b/tv/src/main/res/values/strings.xml
@@ -10,6 +10,9 @@
     <string name="guidedstep_section_advanced_title">Advanced settings</string>
     <string name="guidedstep_section_advanced_description">The settings below can safely be left at their defaults</string>
     <string name="guidedstep_save">Save</string>
+    <string name="guidedstep_test">Test</string>
+    <string name="guidedstep_taste_the_rainbow">Taste the rainbow</string>
+    <string name="guidedstep_test_success"></string>
     <string name="guidedstep_continue">Continue</string>
     <string name="guidedstep_letsdoit">Let\'s do it</string>
     <string name="guidedstep_nevermind">Never mind</string>


### PR DESCRIPTION
- Adds a button to the manual setup screen to test the connection to Hyperion. It temporarily turns on the lights and shows a Toast with the test result
- Also persists priority value, which was omitted earlier