### PR TITLE
slight delay in broadcasting grabber status on successful connection

### DIFF
--- a/common/src/main/java/com/abrenoch/hyperiongrabber/common/HyperionScreenService.java
+++ b/common/src/main/java/com/abrenoch/hyperiongrabber/common/HyperionScreenService.java
@@ -40,7 +40,7 @@ public class HyperionScreenService extends Service {
     private static final int NOTIFICATION_ID = 1;
     private static final int NOTIFICATION_STAT_STOP_INTENT_ID = 2;
     private static final int NOTIFICATION_EXIT_INTENT_ID = 3;
-
+    private static final int SUCCESSFUL_CONNECTION_NOTIFY_DELAY_MS = 100;
     private boolean OGL_GRABBER = false;
     private boolean RECONNECT = false;
     private boolean hasConnected = false;
@@ -58,6 +58,15 @@ public class HyperionScreenService extends Service {
         public void onConnected() {
             Log.d(TAG, "CONNECTED TO HYPERION INSTANCE");
             hasConnected = true;
+
+            // a slight delay here to give the grabber time to fully initialize
+            // before sending the grabber status back to the activity
+            try {
+                Thread.sleep(SUCCESSFUL_CONNECTION_NOTIFY_DELAY_MS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
             notifyActivity();
         }
 


### PR DESCRIPTION
I'm not sure when this timing issue became a thing, but since the `HyperionScreenEncoder` and `HyperionThread` are both started independently, there is a chance that the screen recorder has not fully initialized when sending the grabber status back to the `MainActivity` (thus not showing the grabber as running). The timing of these events came down to a couple milliseconds within each other, so we may have just been lucky not seeing this happen until now. Adding that little bit more logic for the screen scale divisors probably made the difference.

Anyway, seemed like the easiest solution to this problem was to just add a slight delay before notifying the activity of the grabber status (on a successful connection). This seems to have negated the issue entirely for me.

Open to other ideas though.