### PR TITLE
another oom fix

### DIFF
--- a/common/src/main/java/com/abrenoch/hyperiongrabber/common/network/Hyperion.java
+++ b/common/src/main/java/com/abrenoch/hyperiongrabber/common/network/Hyperion.java
@@ -141,7 +141,7 @@ public class Hyperion {
         int size = (header[0]<<24) | (header[1]<<16) | (header[2]<<8) | (header[3]);
 
         HyperionReply reply = null;
-        if (size > 0) {
+        if (size > 0 && size == input.available()) {
             byte[] data = new byte[size];
             input.read(data, 0, size);
             reply = HyperionReply.parseFrom(data);


### PR DESCRIPTION
I noticed a couple bug reports in the play console that had OOM issues still - same problem we ran into before it appears. Seems like using the `BufferdInputStream` *mostly* solved the issue, but not entirely.

This fix simply checks the calculated message size, and only parses the response if that message size is equal to the number of bytes available in the input stream. We could maybe go with a less than or equal to, but this has proven to be effective in my testing so far.

This should put an end to any miscalculated response sizes!