### PR TITLE
Bug/tv assertion error

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,7 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8 (1)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/tv/src/main/java/com/abrenoch/hyperiongrabber/tv/fragments/settings/BasicSettingsStepFragment.kt
+++ b/tv/src/main/java/com/abrenoch/hyperiongrabber/tv/fragments/settings/BasicSettingsStepFragment.kt
@@ -243,10 +243,16 @@ internal class BasicSettingsStepFragment : SettingsStepBaseFragment() {
             val color = TEST_COLORS[colorIdx]
             testCounter++
 
-            val host = assertStringValue(ACTION_HOST_NAME)
-            val port = assertIntValue(ACTION_PORT)
-            val priority = assertIntValue(ACTION_MESSAGE_PRIORITY)
-            testHyperionColor(host, port, priority, color)
+            try {
+                val host = assertStringValue(ACTION_HOST_NAME)
+                val port = assertIntValue(ACTION_PORT)
+                val priority = assertIntValue(ACTION_MESSAGE_PRIORITY)
+                testHyperionColor(host, port, priority, color)
+            } catch (ignored: AssertionError) {
+            }
+
+            return
+
         }
 
         super.onGuidedActionClicked(action)

--- a/tv/src/main/java/com/abrenoch/hyperiongrabber/tv/fragments/settings/SettingsStepBaseFragment.kt
+++ b/tv/src/main/java/com/abrenoch/hyperiongrabber/tv/fragments/settings/SettingsStepBaseFragment.kt
@@ -84,6 +84,7 @@ internal abstract class SettingsStepBaseFragment : GuidedStepSupportFragment() {
      * returns that value. If it is not filled, a toast is shown and this
      * fun @throws a [AssertionError]
      */
+    @Throws(AssertionError::class)
     protected fun assertStringValue(actionId: Long): String {
         with(stringValueForAction(actionId)){
             if (isEmpty()){
@@ -94,6 +95,11 @@ internal abstract class SettingsStepBaseFragment : GuidedStepSupportFragment() {
         }
     }
 
+    /** makes sure a value is filled for the GuidedAction and
+     * returns that value. If it is not filled, a toast is shown and this
+     * fun @throws a [AssertionError]
+     */
+    @Throws(AssertionError::class)
     protected fun assertIntValue(actionId: Long): Int {
         return assertStringValue(actionId).let{
             try {


### PR DESCRIPTION
[TV] Catch all settings assertion errors and annotate for Java interop

...apparently Kotlin does not have Checked exceptions.
Fixes a crash when the user tapped the setup Test button while 
hostname value was invalid. This was caused by the expected 
AssertionError not being caught. 

Fixes https://github.com/abrenoch/hyperion-android-grabber/issues/105