### PR TITLE
Updates the manifest to allow accessing services and activities.

### DIFF
--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -15,9 +15,17 @@
         android:supportsRtl="true"
         tools:targetApi="lollipop">
         <service
-            android:name=".HyperionScreenService"
-            android:exported="false"
-            android:launchMode="singleTask" />
+            android:name="com.abrenoch.hyperiongrabber.common.HyperionScreenService"
+            android:exported="true"
+            android:launchMode="singleTask">
+            <intent-filter>
+                <action android:name="com.abrenoch.hyperiongrabber.common.HyperionScreenService" />
+                <action android:name="com.abrenoch.hyperiongrabber.service.ACTION_START" />
+                <action android:name="com.abrenoch.hyperiongrabber.service.ACTION_STOP" />
+                <action android:name="com.abrenoch.hyperiongrabber.service.ACTION_STATUS" />
+                <action android:name="com.abrenoch.hyperiongrabber.service.ACTION_EXIT" />
+            </intent-filter>
+        </service>
 
         <receiver
             android:name=".HyperionGrabberBootReceiver"
@@ -27,7 +35,7 @@
             </intent-filter>
         </receiver>
 
-        <activity android:name=".BootActivity" android:theme="@style/Theme.Transparent"/>
+        <activity android:name=".BootActivity" android:theme="@style/Theme.Transparent" android:exported="true"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
This addresses #149 I wanted to be able to start/stop the screen recording service without any user input.  This way I could use homeassistant/tasker/etc. to send an adb command when it notices media is playing on my android device then stop it when the media stops.

I've tested these changes out on both a mobile device and an android tv device and I've got it working as expected.

To start:

```
adb shell am start com.abrenoch.hyperiongrabber/com.abrenoch.hyperiongrabber.common.BootActivity
```

To stop:

```
adb shell am startservice -a com.abrenoch.hyperiongrabber.service.ACTION_EXIT --ei com.abrenoch.hyperiongrabber.service.EXTRA_RESULT_CODE -1
```

The only caveat is the first time you start the service you will have to check the box so that it doesn't ask again for the permission.  After that it will work w/o user interaction.