### PR TITLE
Add toggle intent to specify whether to turn the grabber on or off

### DIFF
--- a/common/src/main/java/com/abrenoch/hyperiongrabber/common/ToggleActivity.java
+++ b/common/src/main/java/com/abrenoch/hyperiongrabber/common/ToggleActivity.java
@@ -14,18 +14,25 @@ import androidx.appcompat.app.AppCompatActivity;
 public class ToggleActivity extends AppCompatActivity {
     public static final int REQUEST_MEDIA_PROJECTION = 1;
 
+    private static final String EXTRA_TOGGLE_INTENT = "com.abrenoch.hyperiongrabber.TOGGLE_INTENT";
+
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        Boolean toggleIntent = getToggleIntent();
         boolean serviceRunning = checkForInstance();
 
         if (serviceRunning) {
-            stopService();
-            finish();
+            if (toggleIntent == null || !toggleIntent) {
+                stopService();
+                finish();
+            }
         } else {
-            requestPermission();
+            if (toggleIntent == null || toggleIntent) {
+                requestPermission();
+            }
         }
 
     }
@@ -87,10 +94,17 @@ public class ToggleActivity extends AppCompatActivity {
     }
 
     /** stop recording & stop service */
-
-     private void stopService() {
+    private void stopService() {
         Intent stopIntent = new Intent(ToggleActivity.this, HyperionScreenService.class);
         stopIntent.setAction(HyperionScreenService.ACTION_EXIT);
         startService(stopIntent);
+    }
+
+    private Boolean getToggleIntent() {
+        Bundle extras = getIntent().getExtras();
+        if (extras != null && extras.containsKey(EXTRA_TOGGLE_INTENT)) {
+            return extras.getBoolean(EXTRA_TOGGLE_INTENT);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
I wanted to integrate the grabber into my OpenHAB home automation. Since the start on boot seems not to be working in 1.1 beta I added an extra flag to tell ToggleActivity whether the service should be on or off (or toggled if the extra flag is absent).

Can be invocated by adb via

adb shell am start -n com.abrenoch.hyperiongrabber/com.abrenoch.hyperiongrabber.common.ToggleActivity --ez "com.abrenoch.hyperiongrabber.TOGGLE_INTENT" true
